### PR TITLE
mt7996: add MLO capability support

### DIFF
--- a/mt7996/mcu.c
+++ b/mt7996/mcu.c
@@ -10,6 +10,8 @@
 #include "mac.h"
 #include "eeprom.h"
 
+#define UNI_CHIP_CONFIG_NIC_CAPA 0x3
+
 #define fw_name(_dev, name, ...)	({			\
 	char *_fw;						\
 	switch (mt76_chip(&(_dev)->mt76)) {			\
@@ -3260,6 +3262,79 @@ int mt7996_mcu_fw_dbg_ctrl(struct mt7996_dev *dev, u32 module, u8 level)
 				 sizeof(data), false);
 }
 
+static void
+mt7996_mcu_parse_eml_cap(struct mt7996_dev *dev, u8 *data)
+{
+        struct {
+                u8 rsv[4];
+                __le16 eml_cap;
+                u8 rsv2[6];
+        } __packed *cap = (void *)data;
+
+        dev->phy.eml_cap = le16_to_cpu(cap->eml_cap);
+}
+
+static int mt7996_mcu_get_nic_capability(struct mt7996_dev *dev)
+{
+        struct {
+                u8 _rsv[4];
+
+                __le16 tag;
+                __le16 len;
+        } __packed req = {
+                .tag = cpu_to_le16(UNI_CHIP_CONFIG_NIC_CAPA),
+                .len = cpu_to_le16(sizeof(req) - 4),
+        };
+        struct {
+                __le16 n_element;
+                u8 rsv[2];
+        } __packed *hdr;
+        struct sk_buff *skb;
+        int ret, i;
+
+        ret = mt76_mcu_send_and_get_msg(&dev->mt76,
+                                        MCU_UNI_CMD(CHIP_CONFIG), &req,
+                                        sizeof(req), true, &skb);
+        if (ret)
+                return ret;
+
+        hdr = (void *)skb->data;
+        if (skb->len < sizeof(*hdr)) {
+                ret = -EINVAL;
+                goto out;
+        }
+
+        skb_pull(skb, sizeof(*hdr));
+
+        for (i = 0; i < le16_to_cpu(hdr->n_element); i++) {
+                struct tlv *tlv = (struct tlv *)skb->data;
+                int len;
+
+                if (skb->len < sizeof(*tlv))
+                        break;
+
+                len = le16_to_cpu(tlv->len);
+                if (skb->len < len)
+                        break;
+
+                switch (le16_to_cpu(tlv->tag)) {
+                case MT_NIC_CAP_CHIP_CAP:
+                        dev->phy.chip_cap = le64_to_cpu(*(__le64 *)tlv->data);
+                        break;
+                case MT_NIC_CAP_EML_CAP:
+                        mt7996_mcu_parse_eml_cap(dev, tlv->data);
+                        break;
+                default:
+                        break;
+                }
+
+                skb_pull(skb, len);
+        }
+out:
+        dev_kfree_skb(skb);
+        return ret;
+}
+
 static int mt7996_mcu_set_mwds(struct mt7996_dev *dev, bool enabled)
 {
 	struct {
@@ -3333,12 +3408,16 @@ int mt7996_mcu_init_firmware(struct mt7996_dev *dev)
 			return ret;
 	}
 
-	ret = mt7996_load_firmware(dev);
-	if (ret)
-		return ret;
+        ret = mt7996_load_firmware(dev);
+        if (ret)
+                return ret;
 
-	set_bit(MT76_STATE_MCU_RUNNING, &dev->mphy.state);
-	ret = mt7996_mcu_fw_log_2_host(dev, MCU_FW_LOG_WM, 0);
+        ret = mt7996_mcu_get_nic_capability(dev);
+        if (ret)
+                return ret;
+
+        set_bit(MT76_STATE_MCU_RUNNING, &dev->mphy.state);
+        ret = mt7996_mcu_fw_log_2_host(dev, MCU_FW_LOG_WM, 0);
 	if (ret)
 		return ret;
 

--- a/mt7996/mt7996.h
+++ b/mt7996/mt7996.h
@@ -123,6 +123,9 @@
 #define MT7996_RRO_WINDOW_MAX_SIZE	(MT7996_RRO_WINDOW_MAX_LEN *		\
 					 MT7996_RRO_BA_BITMAP_SESSION_SIZE)
 
+#define MT7996_CHIP_CAP_MLO_EN          BIT(8)
+#define MT7996_CHIP_CAP_MLO_EML_EN      BIT(9)
+
 #define MT7996_RX_BUF_SIZE		(1800 + \
 					 SKB_DATA_ALIGN(sizeof(struct skb_shared_info)))
 #define MT7996_RX_MSDU_PAGE_SIZE	(128 + \
@@ -316,11 +319,14 @@ struct mt7996_phy {
 	u32 ampdu_ref;
 	int txpower;
 
-	struct mt76_mib_stats mib;
-	struct mt76_channel_state state_ts;
+        struct mt76_mib_stats mib;
+        struct mt76_channel_state state_ts;
 
-	u16 orig_chainmask;
-	u16 orig_antenna_mask;
+        u64 chip_cap;
+        u16 eml_cap;
+
+        u16 orig_chainmask;
+        u16 orig_antenna_mask;
 
 	bool has_aux_rx;
 	bool counter_reset;
@@ -588,6 +594,7 @@ void mt7996_init_txpower(struct mt7996_phy *phy);
 int mt7996_txbf_init(struct mt7996_dev *dev);
 void mt7996_reset(struct mt7996_dev *dev);
 int mt7996_run(struct mt7996_phy *phy);
+int mt7996_init_mlo_caps(struct mt7996_phy *phy);
 int mt7996_mcu_init(struct mt7996_dev *dev);
 int mt7996_mcu_init_firmware(struct mt7996_dev *dev);
 int mt7996_mcu_twt_agrt_update(struct mt7996_dev *dev,


### PR DESCRIPTION
## Summary
- expose MLO chip capabilities and EML support in mt7996
- query firmware for chip and EML capabilities
- advertise MLO features to cfg80211 during device init

