### PR TITLE
mt7996: enable unconditional MLO support

### DIFF
--- a/mt7996/init.c
+++ b/mt7996/init.c
@@ -1508,14 +1508,18 @@ int mt7996_register_device(struct mt7996_dev *dev)
 	if (ret)
 		return ret;
 
-	ret = mt7996_register_phy(dev, MT_BAND2);
-	if (ret)
-		return ret;
+        ret = mt7996_register_phy(dev, MT_BAND2);
+        if (ret)
+                return ret;
 
-	ret = mt76_register_device(&dev->mt76, true, mt76_rates,
-				   ARRAY_SIZE(mt76_rates));
-	if (ret)
-		return ret;
+       ret = mt7996_init_mlo_caps(&dev->phy);
+       if (ret)
+               return ret;
+
+        ret = mt76_register_device(&dev->mt76, true, mt76_rates,
+                                   ARRAY_SIZE(mt76_rates));
+        if (ret)
+                return ret;
 
 	mt7996_for_each_phy(dev, phy)
 		mt7996_thermal_init(phy);

--- a/mt7996/main.c
+++ b/mt7996/main.c
@@ -90,9 +90,36 @@ static void mt7996_stop(struct ieee80211_hw *hw, bool suspend)
 {
 }
 
+int mt7996_init_mlo_caps(struct mt7996_phy *phy)
+{
+       struct wiphy *wiphy = phy->mt76->hw->wiphy;
+       static const u8 ext_capa_sta[] = {
+               [2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
+               [7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
+       };
+       static struct wiphy_iftype_ext_capab ext_capab[] = {
+               {
+                       .iftype = NL80211_IFTYPE_STATION,
+                       .extended_capabilities = ext_capa_sta,
+                       .extended_capabilities_mask = ext_capa_sta,
+                       .extended_capabilities_len = sizeof(ext_capa_sta),
+               },
+       };
+
+       ext_capab[0].eml_capabilities = phy->eml_cap;
+       ext_capab[0].mld_capa_and_ops =
+               u16_encode_bits(0, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS);
+
+       wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
+       wiphy->iftype_ext_capab = ext_capab;
+       wiphy->num_iftype_ext_capab = ARRAY_SIZE(ext_capab);
+
+       return 0;
+}
+
 static inline int get_free_idx(u32 mask, u8 start, u8 end)
 {
-	return ffs(~mask & GENMASK(end, start));
+        return ffs(~mask & GENMASK(end, start));
 }
 
 static int get_omac_idx(enum nl80211_iftype type, u64 mask)

--- a/mt7996/mt7996.h
+++ b/mt7996/mt7996.h
@@ -302,10 +302,12 @@ struct mt7996_phy {
 	u8 throttle_state;
 	u32 throttle_temp[2]; /* 0: critical high, 1: maximum */
 
-	u32 rxfilter;
-	u64 omac_mask;
+       u32 rxfilter;
+       u64 omac_mask;
 
-	u16 noise;
+       u16 eml_cap;
+
+       u16 noise;
 
 	s16 coverage_class;
 	u8 slottime;
@@ -768,6 +770,7 @@ int mt76_dfs_start_rdd(struct mt7996_dev *dev, bool force);
 int mt7996_dfs_init_radar_detector(struct mt7996_phy *phy);
 void mt7996_set_stream_he_eht_caps(struct mt7996_phy *phy);
 void mt7996_set_stream_vht_txbf_caps(struct mt7996_phy *phy);
+int mt7996_init_mlo_caps(struct mt7996_phy *phy);
 void mt7996_update_channel(struct mt76_phy *mphy);
 int mt7996_init_debugfs(struct mt7996_dev *dev);
 void mt7996_debugfs_rx_fw_monitor(struct mt7996_dev *dev, const void *data, int len);


### PR DESCRIPTION
## Summary
- add MLO capability initialization for mt7996 and always advertise multi-link operation
- add EML capability storage in mt7996_phy
- initialize MLO support during device registration
