### PR TITLE
mt7996: parse EML capability and gate MLO support

### DIFF
--- a/mt7996/init.c
+++ b/mt7996/init.c
@@ -1508,9 +1508,13 @@ int mt7996_register_device(struct mt7996_dev *dev)
 	if (ret)
 		return ret;
 
-        ret = mt7996_register_phy(dev, MT_BAND2);
-        if (ret)
-                return ret;
+       ret = mt7996_register_phy(dev, MT_BAND2);
+       if (ret)
+               return ret;
+
+       ret = mt7996_mcu_get_nic_capability(dev);
+       if (ret)
+               return ret;
 
        ret = mt7996_init_mlo_caps(&dev->phy);
        if (ret)

--- a/mt7996/main.c
+++ b/mt7996/main.c
@@ -92,7 +92,8 @@ static void mt7996_stop(struct ieee80211_hw *hw, bool suspend)
 
 int mt7996_init_mlo_caps(struct mt7996_phy *phy)
 {
-       struct wiphy *wiphy = phy->mt76->hw->wiphy;
+       struct ieee80211_hw *hw = phy->mt76->hw;
+       struct wiphy *wiphy = hw->wiphy;
        static const u8 ext_capa_sta[] = {
                [2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
                [7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
@@ -106,11 +107,14 @@ int mt7996_init_mlo_caps(struct mt7996_phy *phy)
                },
        };
 
+       if (!phy->eml_cap && !phy->mld_cap)
+               return 0;
+
        ext_capab[0].eml_capabilities = phy->eml_cap;
-       ext_capab[0].mld_capa_and_ops =
-               u16_encode_bits(0, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS);
+       ext_capab[0].mld_capa_and_ops = phy->mld_cap;
 
        wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
+       ieee80211_hw_set(hw, SUPPORTS_MULTI_LINK);
        wiphy->iftype_ext_capab = ext_capab;
        wiphy->num_iftype_ext_capab = ARRAY_SIZE(ext_capab);
 

--- a/mt7996/mt7996.h
+++ b/mt7996/mt7996.h
@@ -306,6 +306,7 @@ struct mt7996_phy {
        u64 omac_mask;
 
        u16 eml_cap;
+       u16 mld_cap;
 
        u16 noise;
 
@@ -645,6 +646,7 @@ int mt7996_mcu_set_fixed_field(struct mt7996_dev *dev, struct mt7996_sta *msta,
 int mt7996_mcu_set_eeprom(struct mt7996_dev *dev);
 int mt7996_mcu_get_eeprom(struct mt7996_dev *dev, u32 offset, u8 *buf, u32 buf_len);
 int mt7996_mcu_get_eeprom_free_block(struct mt7996_dev *dev, u8 *block_num);
+int mt7996_mcu_get_nic_capability(struct mt7996_dev *dev);
 int mt7996_mcu_get_chip_config(struct mt7996_dev *dev, u32 *cap);
 int mt7996_mcu_set_ser(struct mt7996_dev *dev, u8 action, u8 set, u8 band);
 int mt7996_mcu_set_txbf(struct mt7996_dev *dev, u8 action);


### PR DESCRIPTION
## Summary
- parse EML and MLD capabilities from firmware and store in phy
- expose MLO support only when firmware reports capability
- enable multi-link hardware flag when MLO is supported

