### PR TITLE
mt7996: parse EML capability and gate MLO support

### DIFF
--- a/mt7996/init.c
+++ b/mt7996/init.c
@@ -1508,9 +1508,13 @@ int mt7996_register_device(struct mt7996_dev *dev)
 	if (ret)
 		return ret;
 
-        ret = mt7996_register_phy(dev, MT_BAND2);
-        if (ret)
-                return ret;
+       ret = mt7996_register_phy(dev, MT_BAND2);
+       if (ret)
+               return ret;
+
+       ret = mt7996_mcu_get_nic_capability(dev);
+       if (ret)
+               return ret;
 
        ret = mt7996_init_mlo_caps(&dev->phy);
        if (ret)

--- a/mt7996/main.c
+++ b/mt7996/main.c
@@ -92,7 +92,8 @@ static void mt7996_stop(struct ieee80211_hw *hw, bool suspend)
 
 int mt7996_init_mlo_caps(struct mt7996_phy *phy)
 {
-       struct wiphy *wiphy = phy->mt76->hw->wiphy;
+       struct ieee80211_hw *hw = phy->mt76->hw;
+       struct wiphy *wiphy = hw->wiphy;
        static const u8 ext_capa_sta[] = {
                [2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
                [7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
@@ -106,13 +107,24 @@ int mt7996_init_mlo_caps(struct mt7996_phy *phy)
                },
        };
 
+       if (!phy->eml_cap && !phy->mld_cap) {
+               pr_info("mt7996: firmware lacks MLO capability\n");
+               return 0;
+       }
+
+       pr_info("mt7996: enabling MLO (EML 0x%04x, MLD 0x%04x)\n",
+               phy->eml_cap, phy->mld_cap);
+
        ext_capab[0].eml_capabilities = phy->eml_cap;
-       ext_capab[0].mld_capa_and_ops =
-               u16_encode_bits(0, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS);
+       ext_capab[0].mld_capa_and_ops = phy->mld_cap;
 
        wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
        wiphy->iftype_ext_capab = ext_capab;
        wiphy->num_iftype_ext_capab = ARRAY_SIZE(ext_capab);
+
+#ifdef IEEE80211_HW_SUPPORTS_MULTI_LINK
+       ieee80211_hw_set(hw, SUPPORTS_MULTI_LINK);
+#endif
 
        return 0;
 }

--- a/mt7996/mcu.c
+++ b/mt7996/mcu.c
@@ -3901,6 +3901,88 @@ int mt7996_mcu_get_eeprom_free_block(struct mt7996_dev *dev, u8 *block_num)
 	return 0;
 }
 
+static void mt7996_mcu_parse_eml_cap(struct mt7996_dev *dev, char *data)
+{
+       struct mt7996_mcu_eml_cap {
+               u8 rsv[4];
+               __le16 eml_cap;
+               __le16 mld_cap;
+               u8 rsv2[4];
+       } __packed *cap = (struct mt7996_mcu_eml_cap *)data;
+
+       dev->phy.eml_cap = le16_to_cpu(cap->eml_cap);
+       dev->phy.mld_cap = le16_to_cpu(cap->mld_cap);
+
+       pr_info("mt7996: fw EML capability 0x%04x, MLD capability 0x%04x\n",
+               dev->phy.eml_cap, dev->phy.mld_cap);
+}
+
+int mt7996_mcu_get_nic_capability(struct mt7996_dev *dev)
+{
+       struct mt76_phy *mphy = &dev->mt76.phy;
+       struct {
+               u8 _rsv[4];
+
+               __le16 tag;
+               __le16 len;
+       } __packed req = {
+               .tag = cpu_to_le16(UNI_CHIP_CONFIG_NIC_CAPA),
+               .len = cpu_to_le16(sizeof(req) - 4),
+       };
+       struct mt76_connac_cap_hdr {
+               __le16 n_element;
+               u8 rsv[2];
+       } __packed *hdr;
+       struct sk_buff *skb;
+       int ret, i;
+
+       ret = mt76_mcu_send_and_get_msg(&dev->mt76,
+                                       MCU_WM_UNI_CMD_QUERY(CHIP_CONFIG),
+                                       &req, sizeof(req), true, &skb);
+       if (ret)
+               return ret;
+
+       hdr = (struct mt76_connac_cap_hdr *)skb->data;
+       if (skb->len < sizeof(*hdr)) {
+               ret = -EINVAL;
+               goto out;
+       }
+
+       skb_pull(skb, sizeof(*hdr));
+
+       for (i = 0; i < le16_to_cpu(hdr->n_element); i++) {
+               struct tlv *tlv = (struct tlv *)skb->data;
+               int len;
+
+               if (skb->len < sizeof(*tlv))
+                       break;
+
+               len = le16_to_cpu(tlv->len);
+               if (skb->len < len)
+                       break;
+
+               switch (le16_to_cpu(tlv->tag)) {
+               case MT_NIC_CAP_6G:
+                       mphy->cap.has_6ghz = !!tlv->data[0];
+                       break;
+               case MT_NIC_CAP_MAC_ADDR:
+                       memcpy(mphy->macaddr, tlv->data, ETH_ALEN);
+                       break;
+               case MT_NIC_CAP_EML_CAP:
+                       mt7996_mcu_parse_eml_cap(dev, tlv->data);
+                       break;
+               default:
+                       break;
+               }
+
+               skb_pull(skb, len);
+       }
+
+out:
+       dev_kfree_skb(skb);
+
+       return ret;
+}
 int mt7996_mcu_get_chip_config(struct mt7996_dev *dev, u32 *cap)
 {
 #define NIC_CAP	3

--- a/mt7996/mcu.h
+++ b/mt7996/mcu.h
@@ -799,6 +799,11 @@ enum {
 	UNI_CHANNEL_RX_PATH,
 };
 
+enum {
+	UNI_CHIP_CONFIG_CHIP_CFG = 0x2,
+	UNI_CHIP_CONFIG_NIC_CAPA = 0x3,
+};
+
 #define MT7996_BSS_UPDATE_MAX_SIZE	(sizeof(struct bss_req_hdr) +		\
 					 sizeof(struct mt76_connac_bss_basic_tlv) +	\
 					 sizeof(struct bss_rlm_tlv) +		\

--- a/mt7996/mt7996.h
+++ b/mt7996/mt7996.h
@@ -306,6 +306,7 @@ struct mt7996_phy {
        u64 omac_mask;
 
        u16 eml_cap;
+       u16 mld_cap;
 
        u16 noise;
 
@@ -645,6 +646,7 @@ int mt7996_mcu_set_fixed_field(struct mt7996_dev *dev, struct mt7996_sta *msta,
 int mt7996_mcu_set_eeprom(struct mt7996_dev *dev);
 int mt7996_mcu_get_eeprom(struct mt7996_dev *dev, u32 offset, u8 *buf, u32 buf_len);
 int mt7996_mcu_get_eeprom_free_block(struct mt7996_dev *dev, u8 *block_num);
+int mt7996_mcu_get_nic_capability(struct mt7996_dev *dev);
 int mt7996_mcu_get_chip_config(struct mt7996_dev *dev, u32 *cap);
 int mt7996_mcu_set_ser(struct mt7996_dev *dev, u8 action, u8 set, u8 band);
 int mt7996_mcu_set_txbf(struct mt7996_dev *dev, u8 action);


### PR DESCRIPTION
## Summary
- parse EML and MLD capabilities from firmware and store in phy
- expose MLO support only when firmware reports capability and log parsed values
- drop unsupported `IEEE80211_HW_SUPPORTS_MULTI_LINK` flag
- guard `ieee80211_hw_set(hw, SUPPORTS_MULTI_LINK)` behind `IEEE80211_HW_SUPPORTS_MULTI_LINK`

## Testing
- `make` *(fails: No targets. Stop.)*
- `git ls-remote https://github.com/rmandrad/mt76 mt76mtksdk`


------
https://chatgpt.com/codex/tasks/task_e_68a7283dd8088330b1e06808d6139aef